### PR TITLE
Prevent timeout when message is intentionally 0, but still exists

### DIFF
--- a/wait-paths.js
+++ b/wait-paths.js
@@ -60,7 +60,7 @@ module.exports = function(RED) {
                 
                 // guardo variables que van llegando
                 for (var i = 0; i < pathsLength; i++) {
-                    if (msg.paths[paths[i]]) {
+                    if (paths[i] in msg.paths) {
 
                         if ( !node.pathsContol[correlationId] )
                         {


### PR DESCRIPTION
When the message within a path is 0, it is evaluated to "false", even though the key exists. Especially, when the message shall only contain an integer, this could leave to unexpected behavior.

Example:
test = {"foo" : 0, "bar" : "Yes."};
console.log(test["foo"] ? "True" : "False");
  ==> False
console.log("foo" in test ? "True" : "False");
  ==> False